### PR TITLE
Modify query to return matching attachments

### DIFF
--- a/query.py
+++ b/query.py
@@ -1,9 +1,9 @@
 import json
 from dateutil import parser as date_parser
 from datetime import datetime
-from utils.query_opensearch import query_OpenSearch
-from utils.query_sql import append_docket_titles
-from utils.sql import connect
+from queries.utils.query_opensearch import query_OpenSearch
+from queries.utils.query_sql import append_docket_titles
+from queries.utils.sql import connect
 
 def filter_dockets(dockets, filter_params=None):
     if filter_params is None:

--- a/utils/query_opensearch.py
+++ b/utils/query_opensearch.py
@@ -1,4 +1,4 @@
-from utils.opensearch import connect as create_client
+from queries.utils.opensearch import connect as create_client
 
 def query_OpenSearch(search_term, index_name, field_name):
     client = create_client()


### PR DESCRIPTION
Refactors the opensearch query script to take in an index name and a search field name, and uses that to append the number of matching attachments to the result.