### PR TITLE
Fixes issue in production where query params were read incorrectly

### DIFF
--- a/query.py
+++ b/query.py
@@ -184,7 +184,6 @@ def calc_relevance_score(docket):
 
 def search(search_params):
     conn = connect()
-    search_params = json.loads(search_params)
 
     searchTerm = search_params["searchTerm"]
     pageNumber = search_params["pageNumber"]


### PR DESCRIPTION
Query params are already passed in as a dict, so there is no need to call json.loads() in the function.