### PR TITLE
Update Query Sorting and using start date filter

### DIFF
--- a/query.py
+++ b/query.py
@@ -227,6 +227,7 @@ def search(search_params):
         results = append_agency_fields(results, conn)
         results = append_document_counts(results, conn)
         results = append_document_dates(results, conn)
+        results = filter_dockets(results, filterParams)
 
         for docket in results:
             docket["matchQuality"] = calc_relevance_score(docket)
@@ -243,14 +244,14 @@ def search(search_params):
 
         # sort by num comments,
         # sort by date
-        sorted_results1 = sorted(
+        sorted_results = sorted(
             results, key=lambda x: x.get("comments").get("match"), reverse=True
         )
-        sorted_results = sorted(
-            sorted_results1,
-            key=lambda x: date_parser.isoparse(x.get("timelineDates").get("dateModified")).year,
-            reverse=True,
-        )
+        # sorted_results = sorted(
+        #     sorted_results1,
+        #     key=lambda x: date_parser.isoparse(x.get("timelineDates").get("dateModified")).year,
+        #     reverse=True,
+        # )
 
         # print(sorted_results)
 

--- a/query.py
+++ b/query.py
@@ -29,7 +29,7 @@ def filter_dockets(dockets, filter_params=None):
             continue
 
         try:
-            mod_date = date_parser.isoparse(docket.get("dateModified", "1970-01-01T00:00:00Z"))
+            mod_date = date_parser.isoparse(docket.get("timelineDates", {}).get("dateModified", "1970-01-01T00:00:00Z"))
         except Exception:
             mod_date = datetime.datetime(1970, 1, 1)
         if mod_date < start_date or mod_date > end_date:


### PR DESCRIPTION
- Filter out dockets modified before the selected `startDate`
- Sort results only by number of matching comments (`comments.match`)
- Remove sorting by `dateModified`